### PR TITLE
kube: Only attempt to sync IPv4 addresses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,8 @@ Removing the Kubernetes service *will not* remove the Consul registration.
 
 Removing the Consul service can be done with an annotation of `consul8s/service.remove_registration: true`. This will remove the registration in Consul to allow the service to drain.
 
+Only IPv4 addresses will sync to Kubernetes. Kubernetes will only accept IP addresses. DNS records will not be resolved into an address when syncing.
+
 
 ```
 ---


### PR DESCRIPTION
Kube will fail if a non-IP is used when attempting to sync the endpoint.

This otherwise causes a problem when an ELB is registered into Consul and
that service is sync’d back into Kube.

It would be possible to resolve the addresses and add those to Kube. This
may be done in the future or available as an option.