### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Consul8s
 ========
 
-[![Docker Repository on Quay](https://quay.io/repository/reactiveops/consul8s/status "Docker Repository on Quay")](https://quay.io/repository/reactiveops/consul8s)
+[![Docker Repository on Quay](https://quay.io/repository/fairwinds/consul8s/status "Docker Repository on Quay")](https://quay.io/repository/reactiveops/consul8s)
 
 Consul8s is a tool (currently in development) that retrieves services from
 Consul and creates Kubernetes Services. This allows a pod deployed in

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Consul8s
 ========
 
-[![Docker Repository on Quay](https://quay.io/repository/fairwinds/consul8s/status "Docker Repository on Quay")](https://quay.io/repository/reactiveops/consul8s)
+[![Docker Repository on Quay](https://quay.io/repository/reactiveops/consul8s/status "Docker Repository on Quay")](https://quay.io/repository/reactiveops/consul8s)
 
 Consul8s is a tool (currently in development) that retrieves services from
 Consul and creates Kubernetes Services. This allows a pod deployed in

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Consul/Kube integration",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactiveops/consul8s.git"
+    "url": "git+https://github.com/FairwindsOps/consul8s.git"
   },
-  "author": "ReactiveOps",
+  "author": "Fairwinds",
   "license": "Apache2",
   "dependencies": {
-    "k8s-scripts": "git://github.com/reactiveops/k8s-scripts.git#v4.0.1"
+    "k8s-scripts": "git://github.com/FairwindsOps/k8s-scripts.git#v4.0.1"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt') as f:
 setup(
     name='consul8s',
     version='0.0.0',
-    url='https://github.com/reactiveops/consul8s',
+    url='https://github.com/FairwindsOps/consul8s',
     license='Apache2',
     author='Philip Cristiano',
     author_email='philip@fairwinds.com',


### PR DESCRIPTION
Remaining mentions: 
```
./README.rst:[![Docker Repository on Quay](https://quay.io/repository/fairwinds/consul8s/status "Docker Repository on Quay")](https://quay.io/repository/reactiveops/consul8s)
./example_kube_config/example.yml:          image: quay.io/reactiveops/consul8s:v1.0.0
./quay.config:EXTERNAL_REGISTRY_BASE_DOMAIN=quay.io/reactiveops
```